### PR TITLE
chore: Move redirects to separate file

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,3 @@
 [build]
   command = "pnpm run build"
   publish = "dist"
-
-[[redirects]]
-  from = "/springsteen"
-  to = "/"
-  status = 301

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,2 @@
+# Old pages
+/springsteen     /     301


### PR DESCRIPTION
Move redirects to a _redirects file so that this is picked up by Netlify and Cloudflare.