### PR TITLE
feat: automate service worker cache name

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,33 @@
 import { defineConfig, fontProviders } from "astro/config";
 import sitemap from "@astrojs/sitemap";
 import tailwindcss from "@tailwindcss/vite";
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// Stamps a unique cache version into public/service-worker.js on every
+// build, so the service worker's cache is busted automatically on each
+// deploy without needing to hand-edit a version string.
+function injectServiceWorkerVersion() {
+  return {
+    name: "inject-sw-version",
+    hooks: {
+      "astro:build:done": ({ dir }) => {
+        const cacheVersion =
+          process.env.COMMIT_REF?.slice(0, 7) ||
+          new Date().toISOString().slice(0, 19).replace(/[-:T]/g, "");
+
+        const swPath = fileURLToPath(new URL("service-worker.js", dir));
+        const content = readFileSync(swPath, "utf-8").replaceAll(
+          "__CACHE_VERSION__",
+          cacheVersion,
+        );
+        writeFileSync(swPath, content);
+
+        console.log(`service-worker.js cache version → ${cacheVersion}`);
+      },
+    },
+  };
+}
 
 export default defineConfig({
   site: "https://ianbaker.me",
@@ -11,6 +38,7 @@ export default defineConfig({
     sitemap({
       filter: (page) => page !== "https://ianbaker.me/alive/", // Exclude healthcheck page from sitemap
     }),
+    injectServiceWorkerVersion(),
   ],
 
   fonts: [

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,5 +1,7 @@
-// Name your cache — bump the version when you want to invalidate old caches
-const CACHE_NAME = "ianbaker-cache-v1";
+// Cache name — the __CACHE_VERSION__ placeholder is replaced at build time
+// by the inject-sw-version Astro integration (see astro.config.mjs), so a
+// fresh cache name is generated on every deploy without manual bumping.
+const CACHE_NAME = "ianbaker-cache-__CACHE_VERSION__";
 
 // Which files to pre-cache (optional for Astro, but useful for offline)
 const PRECACHE_URLS = [


### PR DESCRIPTION
## Automatically version the service worker cache on every deploy

### Problem
`service-worker.js`'s `CACHE_NAME` was a hardcoded string (`ianbaker-cache-v1`) that had to be bumped by hand to invalidate old caches. It's easy to forget, and when forgotten, deployed changes to cached assets could get silently served stale until a user manually clears storage.

### Change
- Added an `injectServiceWorkerVersion()` Astro integration in `astro.config.mjs`, hooked into `astro:build:done`. After each build it rewrites `service-worker.js`'s cache name using:
  - Netlify's `COMMIT_REF` (first 7 chars), when building on Netlify, or
  - a timestamp fallback, for local builds where `COMMIT_REF` isn't set.
- `public/service-worker.js` now uses a `__CACHE_VERSION__` placeholder in place of the hardcoded version, which the integration replaces at build time.

### Why this approach
- Static assets in `public/` are copied verbatim by Astro, not processed by Vite — so this can't be done via Vite's `define`. A build-lifecycle hook that rewrites the output file after it's copied is the standard way to handle this.
- Ties cache invalidation to the actual commit being deployed rather than a manually maintained counter, so there's nothing to remember on future changes.

### Testing
- Confirmed the placeholder resolves correctly and no stray `__CACHE_VERSION__` text is left behind:
  ```
  const CACHE_NAME = "ianbaker-cache-abc1234";
  ```
- `pnpm build && pnpm preview` — cache name in DevTools → Application → Cache Storage reflects the resolved version, not the placeholder.
- Confirmed `astro dev` still serves the raw placeholder (expected — the hook only runs on `astro build`, not `astro dev`).

### Notes for reviewer
- No new dependencies — only Node built-ins (`node:fs`, `node:url`).
- No change needed to `package.json`; `build` script stays as plain `astro build`.